### PR TITLE
--guess-return

### DIFF
--- a/libexec/seth/seth
+++ b/libexec/seth/seth
@@ -109,6 +109,8 @@ while [[ $1 ]]; do
     -s|--silent)            export SETH_SILENT=yes;;
     -j|--json-output)       export SETH_JSON_OUTPUT=yes;;
 
+       --guess-return)      export SETH_GUESS_RETURN=yes;;
+
     *) printf "${0##*/}: internal error: %q\n" "$1"; exit 1
   esac; shift
 done

--- a/libexec/seth/seth-send
+++ b/libexec/seth/seth-send
@@ -67,5 +67,5 @@ info "${0##*/}: Transaction included in block $number."
 # Warning: Guessing the return value of the transaction by performing the
 # equivalent call on the previous block will produce incorrect results
 # when multiple conflicting transactions are included in the same block.
-info "${0##*/}: note: return value may be inaccurate"
-seth -B "$((number - 1))" call "$TO" "${@:2}"
+[[ $SETH_GUESS_RETURN ]] && info "${0##*/}: note: return value may be inaccurate"
+[[ $SETH_GUESS_RETURN ]] && seth -B "$((number - 1))" call "$TO" "${@:2}"


### PR DESCRIPTION
Require user to specify `-guess-return` or `SETH_GUESS_RETURN` when they want `seth` to guess what the return value of a call is.

Why? Because the guessing won't always be accurate, nor will it always work without error (e.g. testrpc).