### PR TITLE
Returning proper zero exit code from 'seth send'

### DIFF
--- a/libexec/seth/seth-send
+++ b/libexec/seth/seth-send
@@ -60,6 +60,6 @@ echo >&2
 echo >&2 "${0##*/}: Transaction included in block $number."
 [[ $TO ]] || exec seth receipt "$tx" contractAddress
 
-[[ $SETH_GUESS ]] || exit
+[[ $SETH_GUESS ]] || exit 0
 echo >&2 "${0##*/}: warning: return value may be inaccurate"
 seth -B "$((number - 1))" call "$TO" "${@:2}"


### PR DESCRIPTION
If $SETH_GUESS wasn't set, it used to return a non-zero exit code, probably propagating it from '[[ $SETH_GUESS ]]'. Specifying a fixed zero exit code solved the issue.