### PR TITLE
Fixed `seth send` so it can send transactions without any calldata

### DIFF
--- a/libexec/seth/seth-send
+++ b/libexec/seth/seth-send
@@ -36,12 +36,14 @@ if [[ $SETH_CREATE ]]; then
   fi
 else
   TO=$(seth --to-address "$1")
-  DATA=$(seth calldata "${@:2}")
+  if [[ $2 ]]; then
+    DATA=$(seth calldata "${@:2}")
+  fi
 fi
 
 jshon+=(-n {})
 [[ $TO ]] && jshon+=(-s "$TO" -i to)
-jshon+=(-s "$DATA" -i data)
+[[ $DATA ]] && jshon+=(-s "$DATA" -i data)
 jshon+=($(seth --send-params))
 jshon+=(-i append)
 


### PR DESCRIPTION
Before this fix, it was impossible to transfer raw ETH without providing any calldata. What even more, the --usage said it is possible, but it just didn't work.