### PR TITLE
Fixed incorect calldata length message in case of no calldata

### DIFF
--- a/libexec/seth/seth-send
+++ b/libexec/seth/seth-send
@@ -51,7 +51,7 @@ seth --fail "${0##*/}: error: bad tx hash: $tx; account locked?"
 
 [[ $SETH_ASYNC = yes ]] && exec echo "$tx"
 
-bytes=$((${#DATA} - 2))
+[[ $DATA ]] && bytes=$((${#DATA} - 2)) || bytes=0
 echo >&2 "${0##*/}: Published transaction with $bytes bytes of calldata."
 echo >&2 "${0##*/}: $tx"
 echo >&2 -n "${0##*/}: Waiting for transaction receipt..."


### PR DESCRIPTION
When sending transactions with no calldata, the output used to say: `seth-send: Published transaction with -2 bytes of calldata.` because it tried to subtract the length of "0x" from the length of an empty string. I have changed it so the output is correct in both cases.