### PR TITLE
Change receipt check time to 5 seconds when using --chain

### DIFF
--- a/libexec/seth/seth-receipt
+++ b/libexec/seth/seth-receipt
@@ -14,5 +14,7 @@ receipt=$(seth rpc eth_getTransactionReceipt -- "${jshon[@]}")
 [[ ${number-null} != null && $2 ]] && exec seth --field "$2" <<<"$receipt"
 [[ ${number-null} != null ]] && exec echo "$receipt"
 [[ $SETH_ASYNC = yes ]] && seth --fail "${0##*/}: error: not found: $tx"
-sleep 1; [[ $SETH_TICK ]] && printf . >&2
+sleep_seconds=1
+[[ $SETH_CHAIN ]] && sleep_seconds=5
+sleep "$sleep_seconds"; [[ $SETH_TICK ]] && printf . >&2
 exec "$0" "$@"


### PR DESCRIPTION
`seth receipt` checks every second if a transaction was mined. When using `seth -C ethlive` or similar it uses Infura nodes by default. I've noticed that after a while, infura returns an error (not always).

This PR makes it so that `seth receipt` checks every 5 seconds instead of 1 when not using a local node.